### PR TITLE
Adding a normalization check for FeathersJS Service

### DIFF
--- a/src/hooks/add-version.js
+++ b/src/hooks/add-version.js
@@ -108,8 +108,13 @@ export default function (options = {}) {
         return
 
       try {
+        let version = await versions.find({ query })
 
-        let [ version ] = await versions.find({ query })
+        // Normalize the results of .find() into an array
+        if (version::is(Array))
+          [ version ] = version
+        else
+          [ version ] = version.data
 
         // ensure a version exists
         if (!version)

--- a/src/util/get-version.js
+++ b/src/util/get-version.js
@@ -64,7 +64,13 @@ export default async function getVersion (...args) {
     $limit: 1
   }
 
-  const [ version ] = await versions.find({ query })
+  let version = await versions.find({ query })
+
+  // Normalize the results of .find() into an array taking into account
+  if (version::is(Array))
+    [ version ] = version
+  else
+    [ version ] = version.data
 
   return version || null
 


### PR DESCRIPTION
I ran into an issue where when I initialized with a feathers service from `feathers-sequelize`'s `createService()`.

Calls to `.find()` return an object which looks like: 

```js
{ total: 1,
  limit: 10,
  skip: 0,
  data: 
   [ { id: 2,
       list: [Object],
       document: 2025,
       service: 'disablements' 
   } ] 
}
```

Which obviously breaks with the current setup. So this is an attempt to "normalize" the returned value from the `.find()` call.